### PR TITLE
Add support for PHP 5.6+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
   },
   "require": {
     "magento/framework": "100.1.*",
-    "psr/log": "~1.0"
+    "psr/log": "~1.0",
+    "php": ">=5.6.0"
   },
   "authors": [
     {

--- a/src/Block/Head/Preload.php
+++ b/src/Block/Head/Preload.php
@@ -8,7 +8,7 @@ class Preload extends \Magento\Framework\View\Element\AbstractBlock
 
     public function __construct(
         \Magento\Framework\View\Element\Context $context,
-        string $template,
+        $template,
         array $data = []
     ) {
         parent::__construct($context, $data);


### PR DESCRIPTION
Remove the scalar type hint from the block to add support for PHP versions < 7.0.  I've also added a platform requirement for PHP 5.6+ with the rationale that we don't want the testing burden of < 5.6.

Fixes #2.